### PR TITLE
wip for fuzzy json

### DIFF
--- a/examples/fuzzy_search_json.rs
+++ b/examples/fuzzy_search_json.rs
@@ -1,0 +1,121 @@
+// # Basic Example
+//
+// This example covers the basic functionalities of
+// tantivy.
+//
+// We will :
+// - define our schema
+// - create an index in a directory
+// - index a few documents into our index
+// - search for the best document matching a basic query
+// - retrieve the best document's original content.
+// ---
+// Importing tantivy...
+use tantivy::collector::{Count, TopDocs};
+use tantivy::query::{FuzzyTermQuery, Query, QueryParser, QueryParserError, TermQuery};
+use tantivy::{schema::*, Searcher};
+use tantivy::{Index, ReloadPolicy};
+use tempfile::TempDir;
+
+fn make_json_term(
+    query_string: &str,
+    query_parser: &QueryParser,
+) -> Result<Term, QueryParserError> {
+    let json_query =
+        query_parser.parse_query(query_string)?;
+    let mut terms = Vec::new();
+    json_query.query_terms(&mut |term, _| {
+        println!("json term: {:?}", term);
+        terms.push(term.clone());
+    });
+
+    return Ok(terms[0].clone());
+}
+
+fn execute_search_query(query: Box<dyn Query>, searcher: &Searcher) {
+    let (_top_docs, count) = searcher
+        .search(&query, &(TopDocs::with_limit(5), Count))
+        .unwrap();
+    println!("\n **Query matched: {} documents", count.to_string());
+    // for (score, doc_address) in top_docs {
+    //     let retrieved_doc = searcher.doc(doc_address);
+    //     // Note that the score is not lower for the fuzzy hit.
+
+    //     // There's an issue open for that: https://github.com/quickwit-oss/tantivy/issues/563
+    //     println!("score {score:?} doc {}", schema.to_json(&retrieved_doc));
+    //     // score 1.0 doc {"title":["The Diary of Muadib"]}
+    //     //
+    //     // score 1.0 doc {"title":["The Diary of a Young Girl"]}
+    //     //
+    //     // score 1.0 doc {"title":["A Dairy Cow"]}
+    // }
+}
+
+fn main() -> tantivy::Result<()> {
+    let index_path = TempDir::new()?;
+    let mut schema_builder = Schema::builder();
+    let title = schema_builder.add_text_field("title", TEXT | STORED);
+    let _attributes = schema_builder.add_json_field("attributes", STORED | TEXT);
+
+    let schema = schema_builder.build();
+    let index = Index::create_in_dir(&index_path, schema.clone())?;
+    let mut index_writer = index.writer(50_000_000)?;
+    let doc = schema.parse_document(
+        r#"{
+        "title": "gone with the wind",
+        "attributes": {
+            "description": "the best vacuum cleaner ever"
+        }
+    }"#,
+    )?;
+    index_writer.add_document(doc)?;
+    let doc = schema.parse_document(
+        r#"{
+        "title": "tale of two cities",
+        "attributes": {
+            "description": "once in a lifetime"
+        }
+    }"#,
+    )?;
+    index_writer.add_document(doc)?;
+    let doc = schema.parse_document(
+        r#"{
+        "title": "dune",
+        "attributes": {
+            "description": "the quick brown fox"
+        }
+    }"#,
+    )?;
+    index_writer.add_document(doc)?;
+
+    index_writer.commit()?;
+    let reader = index
+        .reader_builder()
+        .reload_policy(ReloadPolicy::OnCommit)
+        .try_into()?;
+    let searcher = reader.searcher();
+
+    // ### FuzzyTermQuery
+    {
+        let search_query = "attributes.description:brown";
+        let query_parser = QueryParser::for_index(&index, vec![title]);
+
+        let json_term = make_json_term(search_query, &query_parser)?;
+        println!("json term field: {:?}", json_term.field());
+        let json_query = FuzzyTermQuery::new(json_term.clone(), 1, true);
+
+        let string_term = Term::from_field_text(title, "done");
+        let string_query = FuzzyTermQuery::new(string_term, 1, true);
+
+        let term_query = TermQuery::new(json_term.clone(), IndexRecordOption::Basic);
+
+        println!("\n json fuzzy query");
+        execute_search_query(Box::new(json_query), &searcher);
+        println!("\n string fuzzy query");
+        execute_search_query(Box::new(string_query), &searcher);
+        println!("\n term query");
+        execute_search_query(Box::new(term_query), &searcher);
+    }
+
+    Ok(())
+}

--- a/examples/json_field.rs
+++ b/examples/json_field.rs
@@ -57,6 +57,7 @@ fn main() -> tantivy::Result<()> {
     let query_parser = QueryParser::for_index(&index, vec![event_type, attributes]);
     {
         let query = query_parser.parse_query("target:submit-button")?;
+        println!("query: {:?}", query);
         let count_docs = searcher.search(&*query, &TopDocs::with_limit(2))?;
         assert_eq!(count_docs.len(), 2);
     }

--- a/examples/phrase_prefix_search.rs
+++ b/examples/phrase_prefix_search.rs
@@ -73,7 +73,11 @@ fn main() -> Result<()> {
         })
         .collect::<Result<Vec<_>>>()?;
     titles.sort_unstable();
-    assert_eq!(titles, ["Frankenstein", "Of Mice and Men"]);
+    print!("titles: ");
+    for title in titles {
+        print!("{}, ", title);
+    }
+    println!("");
 
     Ok(())
 }

--- a/src/query/bm25.rs
+++ b/src/query/bm25.rs
@@ -75,7 +75,7 @@ pub struct Bm25Params {
 }
 
 /// A struct used for computing BM25 scores.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Bm25Weight {
     idf_explain: Explanation,
     weight: Score,
@@ -99,6 +99,7 @@ impl Bm25Weight {
         statistics: &dyn Bm25StatisticsProvider,
         terms: &[Term],
     ) -> crate::Result<Bm25Weight> {
+        println!("bm25 weight for terms");
         assert!(!terms.is_empty(), "Bm25 requires at least one term");
         let field = terms[0].field();
         for term in &terms[1..] {
@@ -110,11 +111,14 @@ impl Bm25Weight {
         }
 
         let total_num_tokens = statistics.total_num_tokens(field)?;
+        println!("total tokens: {:?}", total_num_tokens);
         let total_num_docs = statistics.total_num_docs()?;
+        println!("total docs: {:?}", total_num_docs);
         let average_fieldnorm = total_num_tokens as Score / total_num_docs as Score;
 
         if terms.len() == 1 {
             let term_doc_freq = statistics.doc_freq(&terms[0])?;
+            println!("term doc freq: {:?}", term_doc_freq);
             Ok(Bm25Weight::for_one_term(
                 term_doc_freq,
                 total_num_docs,

--- a/src/query/boost_query.rs
+++ b/src/query/boost_query.rs
@@ -2,7 +2,6 @@ use std::fmt;
 
 use crate::docset::BUFFER_LEN;
 use crate::fastfield::AliveBitSet;
-use crate::query::explanation::does_not_match;
 use crate::query::{EnableScoring, Explanation, Query, Scorer, Weight};
 use crate::{DocId, DocSet, Score, SegmentReader, Term};
 

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -329,7 +329,7 @@ impl QueryParser {
     /// Note that `parse_query` returns an error if the input
     /// is not a valid query.
     pub fn parse_query(&self, query: &str) -> Result<Box<dyn Query>, QueryParserError> {
-        let logical_ast = self.parse_query_to_logical_ast(query)?;
+        let logical_ast: LogicalAst = self.parse_query_to_logical_ast(query)?;
         Ok(convert_to_query(&self.fuzzy, logical_ast))
     }
 

--- a/src/query/term_query/term_query.rs
+++ b/src/query/term_query/term_query.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use super::term_weight::TermWeight;
-use crate::query::bm25::Bm25Weight;
+use crate::query::bm25::{Bm25Weight, self};
 use crate::query::{EnableScoring, Explanation, Query, Weight};
 use crate::schema::IndexRecordOption;
 use crate::Term;
@@ -91,10 +91,12 @@ impl TermQuery {
     ) -> crate::Result<TermWeight> {
         let schema = enable_scoring.schema();
         let field_entry = schema.get_field_entry(self.term.field());
+        println!("term field: {:?}", self.term.field());
         if !field_entry.is_indexed() {
             let error_msg = format!("Field {:?} is not indexed.", field_entry.name());
             return Err(crate::TantivyError::SchemaError(error_msg));
         }
+        println!("term in specialized weight: {:?}", self.term.clone());
         let bm25_weight = match enable_scoring {
             EnableScoring::Enabled {
                 statistics_provider,

--- a/src/query/weight.rs
+++ b/src/query/weight.rs
@@ -76,6 +76,7 @@ pub trait Weight: Send + Sync + 'static {
 
     /// Returns the number documents within the given [`SegmentReader`].
     fn count(&self, reader: &SegmentReader) -> crate::Result<u32> {
+        println!("weight: count");
         let mut scorer = self.scorer(reader, 1.0)?;
         if let Some(alive_bitset) = reader.alive_bitset() {
             Ok(scorer.count(alive_bitset))
@@ -91,6 +92,7 @@ pub trait Weight: Send + Sync + 'static {
         reader: &SegmentReader,
         callback: &mut dyn FnMut(DocId, Score),
     ) -> crate::Result<()> {
+        println!("weight: for each");
         let mut scorer = self.scorer(reader, 1.0)?;
         for_each_scorer(scorer.as_mut(), callback);
         Ok(())
@@ -103,6 +105,7 @@ pub trait Weight: Send + Sync + 'static {
         reader: &SegmentReader,
         callback: &mut dyn FnMut(&[DocId]),
     ) -> crate::Result<()> {
+        println!("weight: for each no score");
         let mut docset = self.scorer(reader, 1.0)?;
 
         let mut buffer = [0u32; BUFFER_LEN];
@@ -126,6 +129,7 @@ pub trait Weight: Send + Sync + 'static {
         reader: &SegmentReader,
         callback: &mut dyn FnMut(DocId, Score) -> Score,
     ) -> crate::Result<()> {
+        println!("weight: for each pruning");
         let mut scorer = self.scorer(reader, 1.0)?;
         for_each_pruning_scorer(scorer.as_mut(), threshold, callback);
         Ok(())


### PR DESCRIPTION
run tests with cargo run --package tantivy --example fuzzy_search_json

I think overall, it's pretty easy to separate the term into the json path + string in FuzzyQuery. The difficult part then becomes trying to score matched documents. I _think_ a big difference between FuzzyQuery and TermQuery is that they use an entirely different weighting / scoring implementations with the former depending on the Automata (which is difficult to understand) and the latter using BM25 to score documents (also don't quite understand). 

Overall it seems like the Automata is what's not matching the term with any of the documents. 